### PR TITLE
feat: load admin users from environment

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,3 +17,7 @@ ELEVENLABS_API_KEY=your_elevenlabs_api_key_here
 
 # Ollama base URL (opzionale, default: http://localhost:11434)
 OLLAMA_BASE_URL=http://localhost:11434
+
+# Admin configuration
+ADMIN_EMAILS=admin@qsa-chatbot.com,desi76@example.com,daniele.dragoni@gmail.com
+ADMIN_ROLES=admin

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -48,6 +48,18 @@ LOCKOUT_DURATION_MINUTES = 30
 
 security = HTTPBearer()
 
+# Admin configuration loaded from environment variables
+ADMIN_EMAILS = [
+    e.strip().lower()
+    for e in os.getenv("ADMIN_EMAILS", "").split(",")
+    if e.strip()
+]
+ADMIN_ROLES = [
+    r.strip().lower()
+    for r in os.getenv("ADMIN_ROLES", "").split(",")
+    if r.strip()
+]
+
 # Pydantic models
 class UserRegistration(BaseModel):
     email: EmailStr
@@ -216,17 +228,13 @@ async def get_current_admin_user(current_user: dict = Depends(get_current_active
 
 def is_admin_user(user: dict) -> bool:
     """Controlla se l'utente ha privilegi di amministratore"""
-    # Verifica se l'utente è admin tramite email o ruolo
-    admin_emails = [
-        "admin@qsa-chatbot.com",
-        "desi76@example.com",  # Aggiungi qui email degli admin
-        "daniele.dragoni@gmail.com",
-    ]
-    
+    user_email = (user.get("email") or "").lower()
+    user_role = (user.get("role") or "").lower()
+
     return (
-        user.get("email") in admin_emails or 
-        user.get("role") == "admin" or
-        user.get("is_admin", False)
+        user_email in ADMIN_EMAILS
+        or user_role in ADMIN_ROLES
+        or user.get("is_admin", False)
     )
 
 # Funzioni per password reset con escrow

--- a/backend/app/auth_routes.py
+++ b/backend/app/auth_routes.py
@@ -19,6 +19,14 @@ import os, jwt
 
 router = APIRouter(prefix="/auth", tags=["authentication"])
 
+# Admin configuration from environment
+ADMIN_EMAILS = [
+    e.strip().lower()
+    for e in os.getenv("ADMIN_EMAILS", "").split(",")
+    if e.strip()
+]
+DEFAULT_ADMIN_EMAIL = ADMIN_EMAILS[0] if ADMIN_EMAILS else ""
+
 @router.post("/register", response_model=TokenResponse)
 async def register_user(user_data: UserRegistration):
     """Registrazione nuovo utente"""
@@ -300,7 +308,7 @@ async def change_password(
 @router.post("/admin/reset-password")
 async def admin_reset_password(
     target_email: str,
-    admin_email: str = "admin@qsa-chatbot.com"  # In produzione verifica admin token
+    admin_email: str = DEFAULT_ADMIN_EMAIL  # In produzione verifica admin token
 ):
     """Reset password utente da parte amministratore con sistema escrow"""
     
@@ -372,7 +380,7 @@ async def update_user_role(user_id: int, payload: RoleUpdate, current_admin: dic
 
 @router.get("/admin/escrow/verify")
 async def verify_escrow_integrity(
-    admin_email: str = "admin@qsa-chatbot.com"  # In produzione verifica admin token
+    admin_email: str = DEFAULT_ADMIN_EMAIL  # In produzione verifica admin token
 ):
     """Verifica integrità sistema escrow"""
     

--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -27,6 +27,11 @@ DEFAULT_ADMIN_PASSWORD=admin123!
 # Se 1, sovrascrive la password dell'admin se esiste già
 DEFAULT_ADMIN_OVERWRITE=0
 
+# Lista di email amministratore (separate da virgola)
+ADMIN_EMAILS=admin@qsa-chatbot.com,desi76@example.com,daniele.dragoni@gmail.com
+# Ruoli che garantiscono privilegi amministratore
+ADMIN_ROLES=admin
+
 # Database paths (gestiti automaticamente con Docker volumes)
 # DATABASE_PATH=/app/storage/databases/qsa_chatbot.db
 # RAG_DATABASE_PATH=/app/storage/databases/rag.db


### PR DESCRIPTION
## Summary
- read admin emails and roles from `ADMIN_EMAILS`/`ADMIN_ROLES` environment variables
- update admin endpoints to use configured default admin email
- document new variables in backend `.env.example`

## Testing
- `python -m py_compile backend/app/auth.py backend/app/auth_routes.py`
- `cd backend && pytest` *(fails: Unescaped '\\' in pyproject.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68bab48de584832e9df663ca3b521994

## Riepilogo di Sourcery

Carica e gestisci gli utenti admin tramite variabili d'ambiente invece di valori hardcoded

Nuove Funzionalità:
- Carica le email e i ruoli degli admin dalle variabili d'ambiente ADMIN_EMAILS e ADMIN_ROLES

Miglioramenti:
- Sostituisce i controlli hardcoded per email e ruoli admin con liste basate sulle variabili d'ambiente
- Introduce DEFAULT_ADMIN_EMAIL per il fallback delle route admin

Documentazione:
- Documenta ADMIN_EMAILS e ADMIN_ROLES in backend/.env.example

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Load and manage admin users via environment variables instead of hardcoded values

New Features:
- Load admin emails and roles from ADMIN_EMAILS and ADMIN_ROLES environment variables

Enhancements:
- Replace hardcoded admin email and role checks with environment-based lists
- Introduce DEFAULT_ADMIN_EMAIL for admin routes fallback

Documentation:
- Document ADMIN_EMAILS and ADMIN_ROLES in backend/.env.example

</details>